### PR TITLE
let users supply extra flags to snmpsimd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ADD data /usr/share/snmpsim/data
 
 EXPOSE 161/udp
 
-CMD snmpsimd --agent-udpv4-endpoint=0.0.0.0:161 --process-user=snmpsim --process-group=nogroup
+CMD snmpsimd --agent-udpv4-endpoint=0.0.0.0:161 --process-user=snmpsim --process-group=nogroup $EXTRA_FLAGS

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ To use your own snmpwalks you should mount a folder with snmpwalks like this:
                tandrup/snmpsim
 
 The filename determines the SNMP community name.
+
+If you want to run snmpsimd with different flags then you can use `EXTRA_FLAGS`, like this:
+
+    docker run -v /somewhere/with/snmpwalks:/usr/share/snmpsim/data \
+               -p 161:161/udp \
+               -e EXTRA_FLAGS="--v3-user=testing --v3-auth-key=testing123"
+               tandrup/snmpsim

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use your own snmpwalks you should mount a folder with snmpwalks like this:
 
 The filename determines the SNMP community name.
 
-If you want to run snmpsimd with different flags then you can use `EXTRA_FLAGS`, like this:
+If you want to run snmpsimd with more flags then you can use `EXTRA_FLAGS`, like this:
 
     docker run -v /somewhere/with/snmpwalks:/usr/share/snmpsim/data \
                -p 161:161/udp \


### PR DESCRIPTION
I found the need to be to setup SNMPv3 users when using this for testing. What do you think about this solution? 

Signed-off-by: Tomas Vestelind <tomas.vestelind@gmail.com>