### PR TITLE
Get snmpsim from pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM debian:jessie
+FROM python:3.4-slim
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-utils snmpsim \
-	&& rm -rf /var/lib/apt/lists/*
+RUN pip install snmpsim
 
 RUN adduser --system snmpsim
 
-ADD data /usr/share/snmpsim/data
+ADD data /usr/local/snmpsim/data
 
 EXPOSE 161/udp
 
-CMD snmpsimd --agent-udpv4-endpoint=0.0.0.0:161 --process-user=snmpsim --process-group=nogroup $EXTRA_FLAGS
+CMD snmpsimd.py --agent-udpv4-endpoint=0.0.0.0:161 --process-user=snmpsim --process-group=nogroup $EXTRA_FLAGS

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By default this image contains an snmpwalk from `demo.snmplabs.com` under commun
 
 To use your own snmpwalks you should mount a folder with snmpwalks like this:
 
-    docker run -v /somewhere/with/snmpwalks:/usr/share/snmpsim/data \
+    docker run -v /somewhere/with/snmpwalks:/usr/local/snmpsim/data \
                -p 161:161/udp \
                tandrup/snmpsim
 
@@ -16,7 +16,7 @@ The filename determines the SNMP community name.
 
 If you want to run snmpsimd with more flags then you can use `EXTRA_FLAGS`, like this:
 
-    docker run -v /somewhere/with/snmpwalks:/usr/share/snmpsim/data \
+    docker run -v /somewhere/with/snmpwalks:/usr/local/snmpsim/data \
                -p 161:161/udp \
                -e EXTRA_FLAGS="--v3-user=testing --v3-auth-key=testing123"
                tandrup/snmpsim


### PR DESCRIPTION
Hi! I suggest using pip instead of apt-get so you can get the latest `snmpsim` version (0.4.4) instead of 
version 0.2.4 that found in debian jessie.